### PR TITLE
Add support for null Activity

### DIFF
--- a/Assets/Hai/ComboGesture/Scripts/Components/ComboGestureCompiler.cs
+++ b/Assets/Hai/ComboGesture/Scripts/Components/ComboGestureCompiler.cs
@@ -14,7 +14,7 @@ namespace Hai.ComboGesture.Scripts.Components
     [System.Serializable]
     public struct GestureComboStageMapper
     {
-        public ComboGestureActivity activity;
+        public ComboGestureActivity activity; // This can be null
         public int stageValue;
     }
 }

--- a/Assets/Hai/ComboGesture/Scripts/Editor/EditorUI/ComboGestureCompilerEditor.cs
+++ b/Assets/Hai/ComboGesture/Scripts/Editor/EditorUI/ComboGestureCompilerEditor.cs
@@ -40,15 +40,37 @@ namespace Hai.ComboGesture.Scripts.Editor.EditorUI
             EditorGUILayout.PropertyField(activityStageName, new GUIContent("Activity Stage name"));
             EditorGUILayout.PropertyField(customEmptyClip, new GUIContent("Custom 2-frame empty animation clip (optional)"));
             comboLayersReorderableList.DoLayoutList();
-        
+
+            var compiler = ((ComboGestureCompiler) target);
             EditorGUI.BeginDisabledGroup(
-                animatorController.objectReferenceValue == null ||
-                (activityStageName.stringValue == null || activityStageName.stringValue.Trim() == "") && comboLayers.arraySize >= 2 ||
-                comboLayers.arraySize == 0
+                ThereIsNoAnimatorController() ||
+                ThereIsNoActivity() ||
+                TheOnlyActivityIsNull() ||
+                ThereIsNoActivityNameForMultipleActivities()
             );
+
+            bool ThereIsNoAnimatorController()
+            {
+                return animatorController.objectReferenceValue == null;
+            }
+
+            bool ThereIsNoActivity()
+            {
+                return comboLayers.arraySize == 0;
+            }
+
+            bool TheOnlyActivityIsNull()
+            {
+                return comboLayers.arraySize == 1 && compiler.comboLayers[0].activity == null;
+            }
+
+            bool ThereIsNoActivityNameForMultipleActivities()
+            {
+                return comboLayers.arraySize >= 2 && (activityStageName.stringValue == null || activityStageName.stringValue.Trim() == "");
+            }
+
             if (GUILayout.Button("Create/Overwrite Animator FX GestureCombo layers"))
             {
-                var compiler = ((ComboGestureCompiler) target);
                 new ComboGestureCompilerInternal(
                     compiler.activityStageName,
                     compiler.comboLayers,

--- a/Assets/Hai/ComboGesture/Scripts/Editor/Internal/ComboGestureCompilerInternal.cs
+++ b/Assets/Hai/ComboGesture/Scripts/Editor/Internal/ComboGestureCompilerInternal.cs
@@ -294,6 +294,14 @@ namespace Hai.ComboGesture.Scripts.Editor.Internal
 
         private static RawGestureManifest FromManifest(ComboGestureActivity activity, AnimationClip fallbackWhen00ClipIsNull)
         {
+            if (activity == null)
+            {
+                return new RawGestureManifest(
+                    Enumerable.Repeat(fallbackWhen00ClipIsNull, 36).ToList(),
+                    new List<AnimationClip>(), 
+                    0.1f);
+            }
+            
             var neutral = activity.anim00 ? activity.anim00 : fallbackWhen00ClipIsNull;
             return new RawGestureManifest(new[]
             {


### PR DESCRIPTION
Allow null Activity when the Compiler has multiple Activities.
This is mainly for use by puppets and animations in order to suspend the face animation.

Closes #4