### PR TITLE
Add customization of analog eyes blinking threshold

### DIFF
--- a/Assets/Hai/ComboGesture/Scripts/Components/ComboGestureCompiler.cs
+++ b/Assets/Hai/ComboGesture/Scripts/Components/ComboGestureCompiler.cs
@@ -9,6 +9,7 @@ namespace Hai.ComboGesture.Scripts.Components
         public List<GestureComboStageMapper> comboLayers;
         public RuntimeAnimatorController animatorController;
         public AnimationClip customEmptyClip;
+        public float analogBlinkingUpperThreshold = 0.7f;
     }
     
     [System.Serializable]

--- a/Assets/Hai/ComboGesture/Scripts/Editor/EditorUI/ComboGestureCompilerEditor.cs
+++ b/Assets/Hai/ComboGesture/Scripts/Editor/EditorUI/ComboGestureCompilerEditor.cs
@@ -14,12 +14,14 @@ namespace Hai.ComboGesture.Scripts.Editor.EditorUI
         public SerializedProperty animatorController;
         public SerializedProperty activityStageName;
         public SerializedProperty customEmptyClip;
+        public SerializedProperty analogBlinkingUpperThreshold;
 
         private void OnEnable()
         {
             animatorController = serializedObject.FindProperty("animatorController");
             activityStageName = serializedObject.FindProperty("activityStageName");
             customEmptyClip = serializedObject.FindProperty("customEmptyClip");
+            analogBlinkingUpperThreshold = serializedObject.FindProperty("analogBlinkingUpperThreshold");
             comboLayers = serializedObject.FindProperty("comboLayers");
         
             // reference: https://blog.terresquall.com/2020/03/creating-reorderable-lists-in-the-unity-inspector/
@@ -32,16 +34,25 @@ namespace Hai.ComboGesture.Scripts.Editor.EditorUI
             comboLayersReorderableList.drawHeaderCallback = ComboLayersListHeader;
         }
     
+        private bool _foldoutAdvanced;
+        
         public override void OnInspectorGUI()
         {
             serializedObject.Update();
 
             EditorGUILayout.PropertyField(animatorController, new GUIContent("FX Animator Controller to overwrite"));
             EditorGUILayout.PropertyField(activityStageName, new GUIContent("Activity Stage name"));
-            EditorGUILayout.PropertyField(customEmptyClip, new GUIContent("Custom 2-frame empty animation clip (optional)"));
+            
+            _foldoutAdvanced = EditorGUILayout.Foldout(_foldoutAdvanced, "Advanced");
+            if (_foldoutAdvanced)
+            {
+                EditorGUILayout.PropertyField(customEmptyClip, new GUIContent("Custom 2-frame empty animation clip (optional)"));
+                EditorGUILayout.PropertyField(analogBlinkingUpperThreshold, new GUIContent("Analog fist blinking threshold", "(0: Eyes are open, 1: Eyes are closed)"));
+            }
+
             comboLayersReorderableList.DoLayoutList();
 
-            var compiler = ((ComboGestureCompiler) target);
+            var compiler = (ComboGestureCompiler) target;
             EditorGUI.BeginDisabledGroup(
                 ThereIsNoAnimatorController() ||
                 ThereIsNoActivity() ||
@@ -75,7 +86,8 @@ namespace Hai.ComboGesture.Scripts.Editor.EditorUI
                     compiler.activityStageName,
                     compiler.comboLayers,
                     compiler.animatorController,
-                    compiler.customEmptyClip
+                    compiler.customEmptyClip,
+                    compiler.analogBlinkingUpperThreshold
                 ).DoOverwriteAnimatorFxLayer();
             }
             EditorGUI.EndDisabledGroup();

--- a/Assets/Hai/ComboGesture/Scripts/Editor/Internal/ComboGestureCompilerInternal.cs
+++ b/Assets/Hai/ComboGesture/Scripts/Editor/Internal/ComboGestureCompilerInternal.cs
@@ -29,13 +29,15 @@ namespace Hai.ComboGesture.Scripts.Editor.Internal
         private readonly List<GestureComboStageMapper> _comboLayers;
         private readonly AnimatorController _animatorController;
         private readonly AnimationClip _customEmptyClip;
+        private readonly float _analogBlinkingUpperThreshold;
 
-        public ComboGestureCompilerInternal(string activityStageName, List<GestureComboStageMapper> comboLayers, RuntimeAnimatorController animatorController, AnimationClip customEmptyClip)
+        public ComboGestureCompilerInternal(string activityStageName, List<GestureComboStageMapper> comboLayers, RuntimeAnimatorController animatorController, AnimationClip customEmptyClip, float analogBlinkingUpperThreshold)
         {
             _activityStageName = activityStageName;
             _comboLayers = comboLayers;
             _animatorController = (AnimatorController) animatorController;
             _customEmptyClip = customEmptyClip;
+            _analogBlinkingUpperThreshold = analogBlinkingUpperThreshold;
         }
 
         public void DoOverwriteAnimatorFxLayer()
@@ -270,7 +272,7 @@ namespace Hai.ComboGesture.Scripts.Editor.Internal
                 transition.AddCondition(AnimatorConditionMode.Equals, 0, HaiGestureComboDisableBlinkingOverrideParamName);
             }
         
-            new GestureCBlinkingCombiner(combinator.IntermediateToBlinking, _activityStageName)
+            new GestureCBlinkingCombiner(combinator.IntermediateToBlinking, _activityStageName, _analogBlinkingUpperThreshold)
                 .Populate(enableBlinking, disableBlinking);
         }
 

--- a/Assets/Hai/ComboGesture/Scripts/Editor/Internal/GestureCBlinkingCombiner.cs
+++ b/Assets/Hai/ComboGesture/Scripts/Editor/Internal/GestureCBlinkingCombiner.cs
@@ -8,14 +8,16 @@ namespace Hai.ComboGesture.Scripts.Editor.Internal
         private readonly Dictionary<IntermediateBlinkingGroup, List<BlinkingCondition>> _combinatorIntermediateToBlinking;
         private readonly string _activityStageName;
         private readonly RawGestureManifest _rgm;
-        private const float WeightUpperThreshold = 0.7f;
-        private const float WeightLowerThreshold = 1f - WeightUpperThreshold;
+        private readonly float _weightUpperThreshold;
+        private readonly float _weightLowerThreshold;
         private const AnimatorConditionMode IsEqualTo = AnimatorConditionMode.Equals;
 
-        public GestureCBlinkingCombiner(Dictionary<IntermediateBlinkingGroup,List<BlinkingCondition>> combinatorIntermediateToBlinking, string activityStageName)
+        public GestureCBlinkingCombiner(Dictionary<IntermediateBlinkingGroup,List<BlinkingCondition>> combinatorIntermediateToBlinking, string activityStageName, float analogBlinkingUpperThreshold)
         {
             _combinatorIntermediateToBlinking = combinatorIntermediateToBlinking;
             _activityStageName = activityStageName;
+            _weightUpperThreshold = analogBlinkingUpperThreshold;
+            _weightLowerThreshold = 1f - _weightUpperThreshold;
         }
 
         public void Populate(AnimatorState enableBlinking, AnimatorState disableBlinking)
@@ -39,7 +41,7 @@ namespace Hai.ComboGesture.Scripts.Editor.Internal
                     foreach (var blinkingCondition in items.Value)
                     {
                         var nullableStageValue = GetNullableStageValue(blinkingCondition);
-                        var threshold = items.Key.Posing ? WeightUpperThreshold : WeightLowerThreshold;
+                        var threshold = items.Key.Posing ? _weightUpperThreshold : _weightLowerThreshold;
                     
                         // TODO: Make this code maintainable
                         if (blinkingCondition.Combo.IsSymmetrical)


### PR DESCRIPTION
An analog fist can have an animation with eyes closed and eyes open.
Add an option in the Compiler to customize the threshold after which eyes are closed.

The option was added in the Compiler for simplicity, as if it were on Activities, it would require special handling for deduplication in the optimization phase for the blinking combiner.

Closes #5