### PR TITLE
Clear residual native blinking by resetting VRCAvatarDescriptor eyeLook blendshapes in generated animations

### DIFF
--- a/Assets/Hai/ComboGesture/Scripts/Components/BlendShapeKey.cs
+++ b/Assets/Hai/ComboGesture/Scripts/Components/BlendShapeKey.cs
@@ -1,0 +1,45 @@
+﻿using System;
+
+namespace Hai.ComboGesture.Scripts.Components
+{
+    [Serializable]
+    public readonly struct BlendShapeKey
+    {
+        public BlendShapeKey(string path, string blendShapeName)
+        {
+            Path = path;
+            BlendShapeName = blendShapeName;
+        }
+
+        public string Path { get; }
+        public string BlendShapeName { get; }
+
+        public static bool operator ==(BlendShapeKey left, BlendShapeKey right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(BlendShapeKey left, BlendShapeKey right)
+        {
+            return !left.Equals(right);
+        }
+
+        public bool Equals(BlendShapeKey other)
+        {
+            return Path == other.Path && BlendShapeName == other.BlendShapeName;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is BlendShapeKey other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((Path != null ? Path.GetHashCode() : 0) * 397) ^ (BlendShapeName != null ? BlendShapeName.GetHashCode() : 0);
+            }
+        }
+    }
+}

--- a/Assets/Hai/ComboGesture/Scripts/Components/BlendShapeKey.cs.meta
+++ b/Assets/Hai/ComboGesture/Scripts/Components/BlendShapeKey.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 53a69acbab1c43889614917e5e047967
+timeCreated: 1600812420

--- a/Assets/Hai/ComboGesture/Scripts/Components/ComboGestureCompiler.cs
+++ b/Assets/Hai/ComboGesture/Scripts/Components/ComboGestureCompiler.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
+using VRC.SDK3.Avatars.Components;
 
 namespace Hai.ComboGesture.Scripts.Components
 {
@@ -29,6 +32,46 @@ namespace Hai.ComboGesture.Scripts.Components
 
         public AnimationClip ignoreParamList;
         public AnimationClip fallbackParamList;
+
+        public VRCAvatarDescriptor avatarDescriptor;
+        public bool bypassMandatoryAvatarDescriptor;
+
+        public static List<BlendShapeKey> FindBlinkBlendshapes(ComboGestureCompiler that)
+        {
+            if (that.avatarDescriptor == null)
+            {
+                return new List<BlendShapeKey>();
+            }
+
+            var eyeLook = that.avatarDescriptor.customEyeLookSettings;
+            if (eyeLook.eyelidsSkinnedMesh == null || eyeLook.eyelidsSkinnedMesh.sharedMesh == null)
+            {
+                return new List<BlendShapeKey>();
+            }
+
+            var relativePathToSkinnedMesh = ResolveRelativePath(that.avatarDescriptor.transform, eyeLook.eyelidsSkinnedMesh.transform);
+            return eyeLook.eyelidsBlendshapes
+                .Select(i => BlendShapeNameIfValid(i, eyeLook))
+                .Where(blendShapeName => blendShapeName != null)
+                .Select(blendShapeName => new BlendShapeKey(relativePathToSkinnedMesh, blendShapeName))
+                .ToList();
+        }
+
+        private static string BlendShapeNameIfValid(int index, VRCAvatarDescriptor.CustomEyeLookSettings settings)
+        {
+            var count = settings.eyelidsSkinnedMesh.sharedMesh.blendShapeCount;
+            return index >= 0 && index < count ? settings.eyelidsSkinnedMesh.sharedMesh.GetBlendShapeName(index) : null;
+        }
+
+        private static string ResolveRelativePath(Transform avatar, Transform item)
+        {
+            if (item.parent != avatar && item.parent != null)
+            {
+                return ResolveRelativePath(avatar, item.parent) + "/" + item.name;
+            }
+
+            return item.name;
+        }
     }
 
     [System.Serializable]

--- a/Assets/Hai/ComboGesture/Scripts/Editor/Internal/ComboGestureCompilerInternal.cs
+++ b/Assets/Hai/ComboGesture/Scripts/Editor/Internal/ComboGestureCompilerInternal.cs
@@ -41,6 +41,7 @@ namespace Hai.ComboGesture.Scripts.Editor.Internal
         private readonly AvatarMask _logicalAvatarMask;
         private readonly AnimatorGenerator _animatorGenerator;
         private readonly string _folderToCreateNeutralizedAssetsIn;
+        private readonly List<CurveKey> _blinkBlendshapes;
 
         public ComboGestureCompilerInternal(string activityStageName,
             List<GestureComboStageMapper> comboLayers,
@@ -52,6 +53,7 @@ namespace Hai.ComboGesture.Scripts.Editor.Internal
             ConflictFxLayerMode compilerConflictFxLayerMode,
             AnimationClip compilerIgnoreParamList,
             AnimationClip compilerFallbackParamList,
+            List<CurveKey> blinkBlendshapes,
             AvatarMask expressionsAvatarMask,
             AvatarMask logicalAvatarMask,
             string folderToCreateNeutralizedAssetsIn)
@@ -69,6 +71,7 @@ namespace Hai.ComboGesture.Scripts.Editor.Internal
             _expressionsAvatarMask = expressionsAvatarMask;
             _logicalAvatarMask = logicalAvatarMask;
             _folderToCreateNeutralizedAssetsIn = folderToCreateNeutralizedAssetsIn;
+            _blinkBlendshapes = blinkBlendshapes;
             _animatorGenerator = new AnimatorGenerator(_animatorController, new StatefulEmptyClipProvider(new ClipGenerator(_customEmptyClip, EmptyClipPath, "ComboGesture")));
         }
 
@@ -284,7 +287,14 @@ namespace Hai.ComboGesture.Scripts.Editor.Internal
             if (_conflictPrevention.ShouldGenerateAnimations)
             {
                 EditorUtility.DisplayProgressBar("GestureCombo", "Generating animations", 0f);
-                activityManifests = new AnimationNeutralizer(activityManifests, _compilerConflictFxLayerMode, _compilerIgnoreParamList, _compilerFallbackParamList, _folderToCreateNeutralizedAssetsIn).NeutralizeManifestAnimations();
+                activityManifests = new AnimationNeutralizer(
+                    activityManifests,
+                    _compilerConflictFxLayerMode,
+                    _compilerIgnoreParamList,
+                    _compilerFallbackParamList,
+                    _blinkBlendshapes,
+                    _folderToCreateNeutralizedAssetsIn
+                ).NeutralizeManifestAnimations();
             }
             var combinator = new IntermediateCombinator(activityManifests);
 


### PR DESCRIPTION
Closes #64