### PR TITLE
Fix incorrect wrapping and scrolling in Expressions Editor on high dpi scaling

### DIFF
--- a/Assets/Hai/ExpressionsEditor/Scripts/Editor/EditorUI/EditorWindows/EeAnimationEditorWindow.cs
+++ b/Assets/Hai/ExpressionsEditor/Scripts/Editor/EditorUI/EditorWindows/EeAnimationEditorWindow.cs
@@ -148,7 +148,7 @@ namespace Hai.ExpressionsEditor.Scripts.Editor.EditorUI.EditorWindows
             GUILayout.EndVertical();
             GUILayout.EndHorizontal();
 
-            _scrollPos = GUILayout.BeginScrollView(_scrollPos, GUILayout.Height(Screen.height - StandardHeight - EditorGUIUtility.singleLineHeight * 2));
+            _scrollPos = GUILayout.BeginScrollView(_scrollPos, GUILayout.Height(position.height - StandardHeight - EditorGUIUtility.singleLineHeight * 2));
             GUILayout.BeginHorizontal();
 
             var widthRun = HalfWidth + TempBorder;
@@ -185,7 +185,7 @@ namespace Hai.ExpressionsEditor.Scripts.Editor.EditorUI.EditorWindows
                 GUILayout.EndVertical();
 
                 widthRun += HalfWidth + TempBorder;
-                if (Screen.width < widthRun)
+                if (position.width < widthRun)
                 {
                     widthRun = HalfWidth + TempBorder;
                     GUILayout.FlexibleSpace();

--- a/Assets/Hai/ExpressionsEditor/Scripts/Editor/EditorUI/EditorWindows/EePropertyExplorerWindow.cs
+++ b/Assets/Hai/ExpressionsEditor/Scripts/Editor/EditorUI/EditorWindows/EePropertyExplorerWindow.cs
@@ -94,7 +94,7 @@ namespace Hai.ExpressionsEditor.Scripts.Editor.EditorUI.EditorWindows
             GUILayout.EndVertical();
             GUILayout.EndHorizontal();
 
-            _scrollPos = GUILayout.BeginScrollView(_scrollPos, GUILayout.Height(Screen.height - EditorGUIUtility.singleLineHeight * 6));
+            _scrollPos = GUILayout.BeginScrollView(_scrollPos, GUILayout.Height(position.height - EditorGUIUtility.singleLineHeight * 6));
             GUILayout.BeginHorizontal();
 
             var widthRun = HalfWidth + TempBorder;
@@ -178,7 +178,7 @@ namespace Hai.ExpressionsEditor.Scripts.Editor.EditorUI.EditorWindows
                 GUILayout.EndVertical();
 
                 widthRun += HalfWidth + TempBorder;
-                if (Screen.width < widthRun)
+                if (position.width < widthRun)
                 {
                     widthRun = HalfWidth + TempBorder;
                     GUILayout.FlexibleSpace();


### PR DESCRIPTION
Screen.width and Screen.height return window size in pixels, so they are different from Unity's logical size on displays which have high dpi scaling.