### PR TITLE
Fix Null Pointer Exception when opening editors

### DIFF
--- a/Packages/dev.hai-vr.cge/Scripts/Editor/EditorUI/CgeEditorWindow.cs
+++ b/Packages/dev.hai-vr.cge/Scripts/Editor/EditorUI/CgeEditorWindow.cs
@@ -60,6 +60,7 @@ namespace Hai.ComboGesture.Scripts.Editor.EditorUI
             _editorHandler = new CgeEditorHandler(new CgeEditorState());
             var blendTreeHandler = new CgeBlendTreeHandler();
             _common = new CgeLayoutCommon(Repaint, _renderingCommands);
+            _common.GuiInit();
             var driver = new CgeActivityEditorDriver(_editorHandler);
             _layoutPreventEyesBlinking = new CgeLayoutPreventEyesBlinking(_common, _editorHandler);
             _layoutFaceExpressionCombiner = new CgeLayoutFaceExpressionCombiner(_common, driver, _editorHandler, _renderingCommands);
@@ -73,11 +74,6 @@ namespace Hai.ComboGesture.Scripts.Editor.EditorUI
 
         private void OnInspectorUpdate()
         {
-            if (_common.MiddleAligned == null)
-            {
-                _common.GuiInit();
-            }
-            
             var active = Selection.activeGameObject;
             if (active == null) return;
 


### PR DESCRIPTION
When opening the editors, a null pointer exception is thrown until OnInspectorUpdate is called.

![imagem](https://github.com/user-attachments/assets/1ef3f914-be5f-4ee6-9ac6-1d6acd1be1f7)

I changed it so CgeCommonLayout.GuiInit is called right when the GUI is enabled and the error does not happen anymore.
